### PR TITLE
fix references to two variables.  change @ to $

### DIFF
--- a/stylus/bordered-pulled.styl
+++ b/stylus/bordered-pulled.styl
@@ -3,7 +3,7 @@
 
 .{$fa-css-prefix}-border {
   padding: .2em .25em .15em;
-  border: solid .08em @fa-border-color;
+  border: solid .08em $fa-border-color;
   border-radius: .1em;
 }
 

--- a/stylus/stacked.styl
+++ b/stylus/stacked.styl
@@ -17,4 +17,4 @@
 }
 .{$fa-css-prefix}-stack-1x { line-height: inherit; }
 .{$fa-css-prefix}-stack-2x { font-size: 2em; }
-.{$fa-css-prefix}-inverse { color: @fa-inverse; }
+.{$fa-css-prefix}-inverse { color: $fa-inverse; }


### PR DESCRIPTION
It looks like there was a typo when converting the less stuff to stylus and the @ variable prefix was left for these two.
