### PR TITLE
Fix literal variable-name inclusion in rotation mixins

### DIFF
--- a/stylus/mixins.styl
+++ b/stylus/mixins.styl
@@ -2,9 +2,9 @@
 // --------------------------
 
 fa-icon-rotate($degrees, $rotation)
-  filter unquote("progid:DXImageTransform.Microsoft.BasicImage(rotation={$rotation})")
+  filter unquote("progid:DXImageTransform.Microsoft.BasicImage(rotation=" + $rotation + ")")
   transform rotate($degrees)
 
 fa-icon-flip($horiz, $vert, $rotation)
-  filter unquote("progid:DXImageTransform.Microsoft.BasicImage(rotation={$rotation}, mirror=1)")
+  filter unquote("progid:DXImageTransform.Microsoft.BasicImage(rotation=" + $rotation + ", mirror=1)")
   transform scale($horiz, $vert)


### PR DESCRIPTION
Stylus was getting confused by the attempted interpolation of the rotation value in the `filter` property and was rendering the `filter` value with a literal `{$rotation}` string in it.  Using string addition resolves the value of the variable and generates a valid `filter` value.
