### PR TITLE
Allow settings to be defined before including the variables file

### DIFF
--- a/stylus/variables.styl
+++ b/stylus/variables.styl
@@ -1,13 +1,13 @@
 // Variables
 // --------------------------
 
-$fa-font-path =        "../fonts"
+$fa-font-path ?=        "../fonts"
 //$fa-font-path =        "//netdna.bootstrapcdn.com/font-awesome/4.1.0/fonts" // for referencing Bootstrap CDN font files directly
-$fa-css-prefix =       fa
-$fa-version =          "4.1.0"
-$fa-border-color =     #eee
-$fa-inverse =          #fff
-$fa-li-width =         (30em / 14)
+$fa-css-prefix ?=       fa
+$fa-version ?=          "4.1.0"
+$fa-border-color ?=     #eee
+$fa-inverse ?=          #fff
+$fa-li-width ?=         (30em / 14)
 
 $fa-var-adjust = "\f042"
 $fa-var-adn = "\f170"


### PR DESCRIPTION
This makes the configuration variables in the `variables.styl` file act as default values that defer to any previously defined variables of the same name, which follows the convention used in the Sass version of Font Awesome (https://github.com/FortAwesome/Font-Awesome/blob/master/scss/_variables.scss).
