### PR TITLE
added helper mixin

### DIFF
--- a/stylus/index.styl
+++ b/stylus/index.styl
@@ -1,1 +1,12 @@
 @import "font-awesome"
+
+fa(icon)
+  display inline-block
+  font-family FontAwesome
+  font-style normal
+  font-weight normal
+  line-height 1
+  -webkit-font-smoothing antialiased
+  -moz-osx-font-smoothing grayscale
+  &:before
+    content $fa-var- + icon


### PR DESCRIPTION
I don't like to mix styling and html structure - styling is done within stylus as much as possible....

to use - don't add classes to your html. rather - add these to your stylus files:
.
.
.
.someSelector
     fa(home)
.
.
.

this will make elements with class 'someSelector' use icon fa-home.
