### PR TITLE
Vendor prefix for webkit animation

### DIFF
--- a/stylus/spinning.styl
+++ b/stylus/spinning.styl
@@ -2,10 +2,13 @@
 // --------------------------
 
 .{$fa-css-prefix}-spin
+	-webkit-animation spin 2s infinite linear
 	animation spin 2s infinite linear
 
 @keyframes spin
 	0%
+		-webkit-transform rotate(0deg)
 		transform rotate(0deg)
 	100%
+		-webkit-transform rotate(359deg)
 		transform rotate(359deg)


### PR DESCRIPTION
Spinning icons don't work in Safari/Chrome stable without the `-webkit-animation` vendor prefix. This brings the behaviour in line with vanilla Font Awesome.

https://github.com/FortAwesome/Font-Awesome/blob/master/css/font-awesome.css#L80